### PR TITLE
Exclusively use amr64 as build machine and host.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,8 +7,7 @@ confinement: strict
 license: GPL-3.0
 grade: devel
 architectures:
-  - build-on: [arm64, amd64]
-    build-for: [arm64]
+  - build-on: [arm64]
 
 
 layout:


### PR DESCRIPTION
Snapcraft GitHub repo connection might prefer amd64 over arm64 when building with both directives.